### PR TITLE
Fix OG image URLs on bracket share pages

### DIFF
--- a/src/routes/bracket/$username.tsx
+++ b/src/routes/bracket/$username.tsx
@@ -1,11 +1,16 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
-import { createServerFn } from "@tanstack/react-start";
+import { createIsomorphicFn, createServerFn } from "@tanstack/react-start";
+import { getRequestUrl } from "@tanstack/react-start/server";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 import { Bracket } from "@/components/bracket/Bracket";
 import { NotFound } from "@/components/NotFound";
 import { getResultsFromBracket } from "@/data/players";
 import "@/styles/share-bracket.css";
+
+const getLocation = createIsomorphicFn()
+	.server(() => getRequestUrl())
+	.client(() => new URL(window.location.href));
 
 const usernameInputSchema = z.object({
 	username: z
@@ -81,7 +86,8 @@ export const Route = createFileRoute("/bracket/$username")({
 	),
 	head: ({ params }) => {
 		const { username } = params;
-		const ogImageUrl = `/api/og/${username}`;
+		const url = getLocation();
+		const ogImageUrl = `${url.origin}/api/og/${username}`;
 		return {
 			meta: [
 				{ title: `${username}'s Bracket | March Mad CSS` },


### PR DESCRIPTION
## Summary
- Bracket share pages (`/bracket/$username`) used **relative URLs** (`/api/og/username`) for OG image meta tags, which social media crawlers can't resolve
- Uses `createIsomorphicFn` + `getRequestUrl` to build absolute URLs (same pattern already used in `__root.tsx`)
- Fixes both `og:image` and `twitter:image` meta tags

## Test plan
- [ ] `pnpm build` passes (verified)
- [ ] Visit `/bracket/someuser` and inspect HTML — `og:image` and `twitter:image` should have full `https://...` URLs
- [ ] Test sharing a bracket link on Twitter/Slack/Facebook and confirm the OG image renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)